### PR TITLE
I've fixed a `TypeError: Cannot destructure property 'user' of '(0 , …

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -6,7 +6,7 @@ import makeWASocket, {
   proto
 } from '@whiskeysockets/baileys';
 import { Boom } from '@hapi/boom';
-import { logger } from './utils';
+import { logger, formatPhoneNumber } from './utils';
 
 export interface WhatsAppMessage {
   from: string;
@@ -300,8 +300,9 @@ Type */menu* to begin! 🚀`;
         throw new Error('WhatsApp socket not initialized');
       }
 
-      await this.socket.sendMessage(to, { text });
-      logger.info(`Message sent to ${to}: ${text.substring(0, 50)}...`);
+      const formattedTo = formatPhoneNumber(to);
+      await this.socket.sendMessage(formattedTo, { text });
+      logger.info(`Message sent to ${formattedTo}: ${text.substring(0, 50)}...`);
     } catch (error) {
       logger.error('Failed to send message:', error);
       throw error;


### PR DESCRIPTION
…WABinary_1.jidDecode)(...)'` that occurred when sending reply messages via WhatsApp.

The error was caused by passing a normalized phone number (e.g., `+1234567890`) to the Baileys library, which expects a JID (e.g., `1234567890@s.whatsapp.net`).

I modified the `sendMessage` function in `src/whatsapp.ts` to use the `formatPhoneNumber` utility from `src/utils.ts`. This ensures that the recipient's address is always converted to the correct JID format before being passed to the Baileys library.