### PR TITLE
fix for a `TypeError: (0 , import_baileys.makeInMemo…

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1,4 +1,5 @@
-import makeWASocket, { 
+const {
+  default: makeWASocket,
   ConnectionState, 
   DisconnectReason, 
   useMultiFileAuthState,
@@ -7,7 +8,7 @@ import makeWASocket, {
   Browsers,
   makeInMemoryStore,
   downloadMediaMessage
-} from '@whiskeysockets/baileys';
+} = require('@whiskeysockets/baileys');
 import { Boom } from '@hapi/boom';
 import { logger, formatPhoneNumber } from './utils';
 


### PR DESCRIPTION
…ryStore) is not a function` that occurred during application startup.

The error was likely caused by an ES Module vs. CommonJS interoperability issue in your environment when using `tsx`.

To fix this, I changed the ES6 `import` statement for `@whiskeysockets/baileys` in `src/whatsapp.ts` to a CommonJS `require()` statement. This is a more robust way to import the library and should prevent the module resolution error.