### PR TITLE
This commit downgrades the `@whiskeysockets/baileys` library from `^6…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@whiskeysockets/baileys": "^6.6.0",
+    "@whiskeysockets/baileys": "6.5.0",
     "@qdrant/js-client-rest": "^1.8.2",
     "@hapi/boom": "^10.0.1",
     "express": "^4.18.2",


### PR DESCRIPTION
….6.0` to a pinned `6.5.0`.

This is done to resolve a persistent `TypeError` that occurs on initialization with newer versions of the library, which appear to have removed or relocated the `makeInMemoryStore` function from the top-level exports.

The file `src/whatsapp.ts` has also been reverted to its original state to ensure full compatibility with the downgraded library version. This provides a stable foundation for the application to run without initialization errors.