### PR TITLE
This commit provides a comprehensive fix for several issues related t…

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -3,7 +3,8 @@ import makeWASocket, {
   DisconnectReason,
   useMultiFileAuthState,
   WAMessage,
-  proto
+  proto,
+  Browsers
 } from '@whiskeysockets/baileys';
 import { Boom } from '@hapi/boom';
 import { logger, formatPhoneNumber } from './utils';
@@ -41,6 +42,7 @@ export class WhatsAppService {
       
       this.socket = makeWASocket({
         auth: state,
+        browser: Browsers.macOS('Desktop'),
         logger: {
           level: 'silent',
           trace: () => {},


### PR DESCRIPTION
…o the Baileys WhatsApp library.

1.  Downgrades `@whiskeysockets/baileys` to a pinned version `6.5.0` to resolve critical initialization errors with newer versions.
2.  Sets a `browser` identity in the socket configuration to prevent connection timeouts that may be caused by WhatsApp throttling default clients.
3.  Fixes a `TypeError` on message sending by ensuring the recipient's phone number is always formatted as a JID.
4.  Fixes session persistence by using `socket.end()` instead of `socket.logout()` during graceful shutdown.