### PR TITLE
fix(whatsapp): Enable QR code printing in terminal

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -33,7 +33,7 @@ export async function startWhatsApp() {
   // Create socket (pass a valid config object — TS will expect 1 argument)
   const sock = makeWASocket({
     auth: state,
-    printQRInTerminal: false,
+    printQRInTerminal: true,
     version,
     browser: ['MacOS', 'SmartDocs-AI', '1.0.0']
   } as any) // 'as any' only if TS complains; remove if not needed


### PR DESCRIPTION
This commit changes the `printQRInTerminal` option in the Baileys socket configuration from `false` to `true`.

This change is necessary to allow users to scan the QR code from their terminal when setting up a new session, which is the expected behavior for testing and initial setup.