### PR TITLE
fix(whatsapp): Correctly render QR code in terminal

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -54,8 +54,6 @@ export async function startWhatsApp() {
       const reason = (lastDisconnect?.error as any)?.output?.statusCode || lastDisconnect?.error
       console.warn(`Connection closed, reason: ${reason}`)
     }
-
-    console.log('connection.update', update)
   })
 
   // Incoming messages


### PR DESCRIPTION
This commit fixes an issue where the QR code was not being displayed correctly in the terminal.

The root cause was an extra `console.log` statement in the `connection.update` event handler that was interfering with the terminal's rendering of the QR code block generated by `qrcode-terminal`.

This commit removes the interfering `console.log` statement, ensuring that the QR code is displayed cleanly when a new session is required.