### PR TITLE
fix(whatsapp): Implement auto-reconnection on stream error

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -51,8 +51,13 @@ export async function startWhatsApp() {
     }
 
     if (connection === 'close') {
-      const reason = (lastDisconnect?.error as any)?.output?.statusCode || lastDisconnect?.error
-      console.warn(`Connection closed, reason: ${reason}`)
+      const shouldReconnect = (lastDisconnect?.error as any)?.output?.statusCode !== DisconnectReason.loggedOut
+      console.warn(`Connection closed, reason: ${lastDisconnect?.error}, reconnecting: ${shouldReconnect}`)
+      if (shouldReconnect) {
+        startWhatsApp()
+      } else {
+        console.error('Connection closed permanently, please delete wa-bot-session and restart.')
+      }
     }
   })
 


### PR DESCRIPTION
This commit fixes an issue where the application would not automatically reconnect after the initial QR code scan and login.

The Baileys library emits a `connection.update` event with a "close" status and a specific error code (like 515) to indicate that a restart is required.

This commit updates the `connection.update` event handler to:
1.  Detect when a reconnect is required (i.e., the disconnect reason is not a permanent logout).
2.  Recursively call the `startWhatsApp()` function to re-establish the connection.

This ensures a seamless login process and robustly handles unexpected disconnections.